### PR TITLE
refactor: list vaults server update

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,18 +1,11 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/fs"
 	"log"
 	"net/http"
-	"os"
-	"path"
-	"path/filepath"
+	"strings"
 
 	"github.com/gorilla/mux"
-	"github.com/michaeltukdev/Potok/internal/database"
 	"github.com/michaeltukdev/Potok/internal/middleware"
 )
 
@@ -23,227 +16,235 @@ func StartServer() {
 	api.Use(middleware.ApiMiddleware)
 
 	// Vaults
-	api.HandleFunc("/users/{user}/vaults", handleVaults)
-	api.HandleFunc("/users/{user}/vaults/{vault}", handlePostVault).Methods("POST")
+	api.HandleFunc("/vaults", listVaults).Methods("GET")
+
+	// Vaults
+	// api.HandleFunc("/users/{user}/vaults", handleVaults)
+	// api.HandleFunc("/users/{user}/vaults/{vault}", handlePostVault).Methods("POST")
 	// api.HandleFunc("/users/{user}/vaults/{vault}", handleDeleteVault).Methods("DELETE")
 
 	// Files
-	api.HandleFunc("/users/{user}/vaults/{vault}/files", handleListVaultFiles).Methods("GET")
-	api.HandleFunc("/users/{user}/vaults/{vault}/files/{filepath:.*}", handleDownloadFile).Methods("GET")
-	api.HandleFunc("/users/{user}/vaults/{vault}/files/{filepath:.*}", handleUploadFile).Methods("POST")
+	// api.HandleFunc("/users/{user}/vaults/{vault}/files", handleListVaultFiles).Methods("GET")
+	// api.HandleFunc("/users/{user}/vaults/{vault}/files/{filepath:.*}", handleDownloadFile).Methods("GET")
+	// api.HandleFunc("/users/{user}/vaults/{vault}/files/{filepath:.*}", handleUploadFile).Methods("POST")
 
 	// Authenticated user info
-	api.HandleFunc("/me", handleMe).Methods("GET")
+	// api.HandleFunc("/me", handleMe).Methods("GET")
 
 	log.Println("Starting server on :8080")
 	http.ListenAndServe(":8080", r)
 }
 
-// handleVaults returns all vaults for the authenticated user.
-func handleVaults(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
-	vaults, err := database.FetchUserVaults(r.Header.Get("Authorization"))
-	if err != nil {
-		http.Error(w, "Unauthorized or error fetching vaults", http.StatusUnauthorized)
-		return
-	}
-
-	if err := json.NewEncoder(w).Encode(vaults); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+func extractAPIKey(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	return strings.TrimPrefix(h, "Bearer ")
 }
 
-// handlePostVaults creates a vault with the data passed in by the user.
-func handlePostVault(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+// // handleVaults returns all vaults for the authenticated user.
+// func handleVaults(w http.ResponseWriter, r *http.Request) {
+// 	w.Header().Set("Content-Type", "application/json")
 
-	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
-	if err != nil {
-		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
-		return
-	}
+// 	vaults, err := database.FetchUserVaults(r.Header.Get("Authorization"))
+// 	if err != nil {
+// 		http.Error(w, "Unauthorized or error fetching vaults", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	vars := mux.Vars(r)
-	urlUser := vars["user"]
-	urlVault := vars["vault"]
+// 	if err := json.NewEncoder(w).Encode(vaults); err != nil {
+// 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+// 		return
+// 	}
+// }
 
-	if urlUser != user.Username {
-		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
-		return
-	}
+// // handlePostVaults creates a vault with the data passed in by the user.
+// func handlePostVault(w http.ResponseWriter, r *http.Request) {
+// 	w.Header().Set("Content-Type", "application/json")
 
-	if _, err := database.FetchUserVaultByName(user.Api_key, urlVault); err == nil {
-		http.Error(w, "Vault already exists", http.StatusConflict)
-		return
-	}
+// 	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
+// 	if err != nil {
+// 		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	newVault, err := database.CreateVault(user.Id, urlVault)
-	if err != nil {
-		http.Error(w, "Failed to create vault", http.StatusInternalServerError)
-		return
-	}
+// 	vars := mux.Vars(r)
+// 	urlUser := vars["user"]
+// 	urlVault := vars["vault"]
 
-	w.WriteHeader(http.StatusCreated)
-	if err := json.NewEncoder(w).Encode(newVault); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
-}
+// 	if urlUser != user.Username {
+// 		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
+// 		return
+// 	}
 
-// func handleDeleteVault(w http.ResponseWriter, r *http.Request) {}
-// func handleUploadVault(w http.ResponseWriter, r *http.Request)   {}
-// func handleDownloadVault(w http.ResponseWriter, r *http.Request) {}
+// 	if _, err := database.FetchUserVaultByName(user.Api_key, urlVault); err == nil {
+// 		http.Error(w, "Vault already exists", http.StatusConflict)
+// 		return
+// 	}
 
-// handleDownloadFile takes in data from the client, and returns a specific file from the vault.
-func handleDownloadFile(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/octet-stream")
+// 	newVault, err := database.CreateVault(user.Id, urlVault)
+// 	if err != nil {
+// 		http.Error(w, "Failed to create vault", http.StatusInternalServerError)
+// 		return
+// 	}
 
-	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
-	if err != nil {
-		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
-		return
-	}
+// 	w.WriteHeader(http.StatusCreated)
+// 	if err := json.NewEncoder(w).Encode(newVault); err != nil {
+// 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+// 		return
+// 	}
+// }
 
-	vars := mux.Vars(r)
-	urlUser := vars["user"]
-	urlVault := vars["vault"]
-	filepathInVault := vars["filepath"]
+// // func handleDeleteVault(w http.ResponseWriter, r *http.Request) {}
+// // func handleUploadVault(w http.ResponseWriter, r *http.Request)   {}
+// // func handleDownloadVault(w http.ResponseWriter, r *http.Request) {}
 
-	if urlUser != user.Username {
-		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
-		return
-	}
+// // handleDownloadFile takes in data from the client, and returns a specific file from the vault.
+// func handleDownloadFile(w http.ResponseWriter, r *http.Request) {
+// 	w.Header().Set("Content-Type", "application/octet-stream")
 
-	if _, err := database.FetchUserVaultByName(user.Api_key, urlVault); err == nil {
-		http.Error(w, "Vault already exists", http.StatusConflict)
-		return
-	}
+// 	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
+// 	if err != nil {
+// 		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	fullPath := path.Join("../../data", user.Username, urlVault, filepathInVault)
+// 	vars := mux.Vars(r)
+// 	urlUser := vars["user"]
+// 	urlVault := vars["vault"]
+// 	filepathInVault := vars["filepath"]
 
-	f, err := os.Open(fullPath)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("File not found: %s", fullPath), http.StatusNotFound)
-		return
-	}
-	defer f.Close()
+// 	if urlUser != user.Username {
+// 		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	w.WriteHeader(http.StatusOK)
-	if _, err := io.Copy(w, f); err != nil {
-		http.Error(w, "Failed to send file", http.StatusInternalServerError)
-		return
-	}
-}
+// 	if _, err := database.FetchUserVaultByName(user.Api_key, urlVault); err == nil {
+// 		http.Error(w, "Vault already exists", http.StatusConflict)
+// 		return
+// 	}
 
-// handleUploadFile handles uploading a file to a specific vault for the authenticated user.
-func handleUploadFile(w http.ResponseWriter, r *http.Request) {
-	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
-	if err != nil {
-		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
-		return
-	}
+// 	fullPath := path.Join("../../data", user.Username, urlVault, filepathInVault)
 
-	vars := mux.Vars(r)
-	urlUser := vars["user"]
-	vault := vars["vault"]
-	filepathInVault := vars["filepath"]
+// 	f, err := os.Open(fullPath)
+// 	if err != nil {
+// 		http.Error(w, fmt.Sprintf("File not found: %s", fullPath), http.StatusNotFound)
+// 		return
+// 	}
+// 	defer f.Close()
 
-	if urlUser != user.Username {
-		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
-		return
-	}
+// 	w.WriteHeader(http.StatusOK)
+// 	if _, err := io.Copy(w, f); err != nil {
+// 		http.Error(w, "Failed to send file", http.StatusInternalServerError)
+// 		return
+// 	}
+// }
 
-	fetchedVault, err := database.FetchUserVaultByName(user.Api_key, vault)
-	if err != nil {
-		http.Error(w, "Vault not found or unauthorized", http.StatusUnauthorized)
-		return
-	}
+// // handleUploadFile handles uploading a file to a specific vault for the authenticated user.
+// func handleUploadFile(w http.ResponseWriter, r *http.Request) {
+// 	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
+// 	if err != nil {
+// 		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	fullPath := path.Join("../../data", user.Username, fetchedVault.Name, filepathInVault)
+// 	vars := mux.Vars(r)
+// 	urlUser := vars["user"]
+// 	vault := vars["vault"]
+// 	filepathInVault := vars["filepath"]
 
-	if err := os.MkdirAll(path.Dir(fullPath), 0700); err != nil {
-		http.Error(w, "Failed to create directories", http.StatusInternalServerError)
-		return
-	}
+// 	if urlUser != user.Username {
+// 		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	f, err := os.Create(fullPath)
-	if err != nil {
-		http.Error(w, "Failed to save file", http.StatusInternalServerError)
-		return
-	}
-	defer f.Close()
-	if _, err := io.Copy(f, r.Body); err != nil {
-		http.Error(w, "Failed to write file", http.StatusInternalServerError)
-		return
-	}
+// 	fetchedVault, err := database.FetchUserVaultByName(user.Api_key, vault)
+// 	if err != nil {
+// 		http.Error(w, "Vault not found or unauthorized", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	w.WriteHeader(http.StatusCreated)
-}
+// 	fullPath := path.Join("../../data", user.Username, fetchedVault.Name, filepathInVault)
 
-// handleMe returns information about the authenticated user.
-func handleMe(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+// 	if err := os.MkdirAll(path.Dir(fullPath), 0700); err != nil {
+// 		http.Error(w, "Failed to create directories", http.StatusInternalServerError)
+// 		return
+// 	}
 
-	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
-	if err != nil {
-		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
-		return
-	}
+// 	f, err := os.Create(fullPath)
+// 	if err != nil {
+// 		http.Error(w, "Failed to save file", http.StatusInternalServerError)
+// 		return
+// 	}
+// 	defer f.Close()
+// 	if _, err := io.Copy(f, r.Body); err != nil {
+// 		http.Error(w, "Failed to write file", http.StatusInternalServerError)
+// 		return
+// 	}
 
-	resp := struct {
-		Username string `json:"username"`
-		ID       int    `json:"id"`
-	}{
-		Username: user.Username,
-		ID:       user.Id,
-	}
+// 	w.WriteHeader(http.StatusCreated)
+// }
 
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
-}
+// // handleMe returns information about the authenticated user.
+// func handleMe(w http.ResponseWriter, r *http.Request) {
+// 	w.Header().Set("Content-Type", "application/json")
 
-// handleListVaultFiles returns a JSON array of all file paths in the specified vault for the authenticated user.
-func handleListVaultFiles(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+// 	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
+// 	if err != nil {
+// 		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
-	if err != nil {
-		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
-		return
-	}
+// 	resp := struct {
+// 		Username string `json:"username"`
+// 		ID       int    `json:"id"`
+// 	}{
+// 		Username: user.Username,
+// 		ID:       user.Id,
+// 	}
 
-	vars := mux.Vars(r)
-	urlUser := vars["user"]
-	urlVault := vars["vault"]
+// 	if err := json.NewEncoder(w).Encode(resp); err != nil {
+// 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+// 		return
+// 	}
+// }
 
-	if urlUser != user.Username {
-		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
-		return
-	}
+// // handleListVaultFiles returns a JSON array of all file paths in the specified vault for the authenticated user.
+// func handleListVaultFiles(w http.ResponseWriter, r *http.Request) {
+// 	w.Header().Set("Content-Type", "application/json")
 
-	if _, err := database.FetchUserVaultByName(user.Api_key, urlVault); err == nil {
-		http.Error(w, "Vault already exists", http.StatusConflict)
-		return
-	}
+// 	user, err := database.FindByAPIKey(r.Header.Get("Authorization"))
+// 	if err != nil {
+// 		http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
+// 		return
+// 	}
 
-	vaultDir := path.Join("../../data", user.Username, urlVault)
+// 	vars := mux.Vars(r)
+// 	urlUser := vars["user"]
+// 	urlVault := vars["vault"]
 
-	var files []string
-	filepath.WalkDir(vaultDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+// 	if urlUser != user.Username {
+// 		http.Error(w, "Unauthorized: user mismatch", http.StatusUnauthorized)
+// 		return
+// 	}
 
-		if !d.IsDir() {
-			rel, _ := filepath.Rel(vaultDir, path)
-			files = append(files, rel)
-		}
-		return nil
-	})
+// 	if _, err := database.FetchUserVaultByName(user.Api_key, urlVault); err == nil {
+// 		http.Error(w, "Vault already exists", http.StatusConflict)
+// 		return
+// 	}
 
-	json.NewEncoder(w).Encode(files)
-}
+// 	vaultDir := path.Join("../../data", user.Username, urlVault)
+
+// 	var files []string
+// 	filepath.WalkDir(vaultDir, func(path string, d fs.DirEntry, err error) error {
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		if !d.IsDir() {
+// 			rel, _ := filepath.Rel(vaultDir, path)
+// 			files = append(files, rel)
+// 		}
+// 		return nil
+// 	})
+
+// 	json.NewEncoder(w).Encode(files)
+// }

--- a/internal/api/vaults.go
+++ b/internal/api/vaults.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/michaeltukdev/Potok/internal/database"
+)
+
+func listVaults(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	apiKey := extractAPIKey(r)
+	user, err := database.AuthenticateByKey(apiKey)
+	if err != nil {
+		http.Error(w, "Invalid API Key", http.StatusUnauthorized)
+		return
+	}
+
+	vaults, err := database.FetchUserVaults(user.Id)
+	if err != nil {
+		http.Error(w, "Internal Error", http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(vaults)
+}

--- a/internal/database/auth.go
+++ b/internal/database/auth.go
@@ -11,14 +11,14 @@ type User struct {
 	Api_key  string
 }
 
-func FindByAPIKey(apiKey string) (*User, error) {
+func AuthenticateByKey(apiKey string) (*User, error) {
 	row := DB.QueryRow("SELECT id, username, api_key FROM users WHERE api_key = ?", apiKey)
 
 	var user User
 	err := row.Scan(&user.Id, &user.Username, &user.Api_key)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errors.New("user not found")
+			return nil, errors.New("Incorrect Credentials")
 		}
 		return nil, err
 	}

--- a/internal/database/vault.go
+++ b/internal/database/vault.go
@@ -15,19 +15,14 @@ type Vault struct {
 	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
 }
 
-func FetchUserVaults(apiKey string) ([]Vault, error) {
-	user, err := FindByAPIKey(apiKey)
-	if err != nil {
-		return nil, errors.New("user not found")
-	}
-
-	rows, err := DB.Query("SELECT id, user_id, name, created_at, updated_at FROM vaults WHERE user_id = ?", user.Id)
+func FetchUserVaults(userID int) ([]Vault, error) {
+	rows, err := DB.Query("SELECT id, user_id, name, created_at, updated_at FROM vaults WHERE user_id = ?", userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var vaults []Vault
+	vaults := []Vault{}
 	for rows.Next() {
 		var v Vault
 		if err := rows.Scan(&v.ID, &v.UserID, &v.Name, &v.CreatedAt, &v.UpdatedAt); err != nil {
@@ -36,19 +31,11 @@ func FetchUserVaults(apiKey string) ([]Vault, error) {
 		vaults = append(vaults, v)
 	}
 
-	if vaults == nil {
-		vaults = []Vault{}
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return vaults, nil
+	return vaults, rows.Err()
 }
 
 func FetchUserVaultByName(apiKey, vaultName string) (*Vault, error) {
-	user, err := FindByAPIKey(apiKey)
+	user, err := AuthenticateByKey(apiKey)
 	if err != nil {
 		return nil, errors.New("user not found")
 	}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -14,7 +14,7 @@ func ApiMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		_, err := database.FindByAPIKey(authHeader)
+		_, err := database.AuthenticateByKey(authHeader)
 		if err != nil {
 			http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 			return


### PR DESCRIPTION
- Fix server API routes to set route methods.
- Drop the `/users/{user}/vaults` for just `/vaults` route prefix to simplify implementation.
- Move authentication out of FetchUserVaults so it only handles querying vaults by User ID